### PR TITLE
Modify changed type name: uri → url

### DIFF
--- a/syntax/nirum.vim
+++ b/syntax/nirum.vim
@@ -19,7 +19,7 @@ syn keyword NirumPrimitiveNumberType bigint decimal int32 int64 float32 float64
 syn keyword NirumPrimitiveStringType text binary
 syn keyword NirumPrimitiveTimeType datetime date
 syn keyword NirumPrimitiveBoolType bool
-syn keyword NirumPrimitiveEtcType uuid uri
+syn keyword NirumPrimitiveEtcType uuid url
 syn match NirumAnnotation /@\s*[a-zA-Z]\+[\-_a-zA-Z0-9]*\s*\((\("[^"]*"\)\?)\)\?/
 
 hi! link NirumTypeDecl                        Keyword


### PR DESCRIPTION
Since `uri` changed its name to `url` on [Nirum 0.4.0](https://github.com/spoqa/nirum/blob/0.4-maintenance/CHANGES.md#version-040), It has to be applied to syntax highlighter as well.

Please review this PR. @dahlia 